### PR TITLE
FO-293 (bug) Remove the declaration of the unused 'cmd' variable.

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,6 @@ app.get('/user', (req, res) => {
 
 // Command Injection Vulnerable Endpoint
 app.get('/exec', (req, res) => {
-    const cmd = req.query.cmd;
-
     res.send('Code has been changed to prevent constructing the OS command from user-controlled data.');
 });
 


### PR DESCRIPTION
FO-293 (bug) Remove the declaration of the unused 'cmd' variable.